### PR TITLE
Parametrize log and run directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ nifi_config_dirs:
   install: /opt/nifi/releases
   home: /opt/nifi/releases/current
   external_config: /opt/nifi/config_resources
+  run: {{ nifi_config_dirs.home }}/run
+  logs: {{ nifi_config_dirs.home }}/logs
 ```
 
 By default, this is the directory structure that will be created:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ nifi_config_dirs:
   install: /opt/nifi/releases
   home: /opt/nifi/releases/current
   external_config: /opt/nifi/config_resources
+  run: /opt/nifi/releases/current/run
+  logs: /opt/nifi/releases/current/logs
 
 # Specify any property from nifi.properties here.
 nifi_properties:

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -14,15 +14,28 @@
     create_home: "no"
     system: "yes"
 
-- name: Create install directory
+- name: Create directories
   file:
-    path: "{{ nifi_config_dirs.install }}"
+    path: "{{ item }}"
     state: "directory"
     owner: "{{ nifi_user }}"
     group: "{{ nifi_group }}"
+  with_items:
+    - "{{ nifi_config_dirs.install }}"
+    - "{{ nifi_config_dirs.run }}"
+    - "{{ nifi_config_dirs.logs }}"
 
 - name: Set NiFi home
   lineinfile:
     path: "/etc/environment"
     line: "export NIFI_HOME={{ nifi_config_dirs.home }}"
     create: "yes"
+
+- name: Set NiFi run and logs in env.sh
+  lineinfile:
+    path: "{{ nifi_config_dirs.home }}/bin/nifi-env.sh"
+    line: "{{ item.key }}={{ item.value }}"
+    regexp: "^{{ item.key }}"
+  with_dict:
+    "export NIFI_PID_DIR": "{{ nifi_config_dirs.run }}"
+    "export NIFI_LOG_DIR": "{{ nifi_config_dirs.logs }}"


### PR DESCRIPTION
Log and run directories setup is located inside of nifi-env.sh. In order to change them it is needed to overwrite default values of _NIFI_LOG_DIR_ and _NIFI_PID_DIR_. Overwrite of _/etc/profile.d/nifi.sh_ or _/etc/environment_ doesn't work