### PR TITLE
Fix hardcoded unpack location in install.yml

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,7 @@
 - name: Unpack NiFi binary
   unarchive:
     remote_src: "yes"
-    src: "/tmp/nifi-{{ nifi_version }}-bin.tar.gz"
+    src: "{{ nifi_config_dirs.binaries }}/nifi-{{ nifi_version }}-bin.tar.gz"
     dest: "{{ nifi_config_dirs.install }}/"
     owner: "{{ nifi_user }}"
     group: "{{ nifi_group }}"


### PR DESCRIPTION
Use the configured location as proven by the stat check task at the top, instead of the hardcoded /tmp path.