### PR TITLE
 On branch fix/idempotency

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+--- 
+- name: restart_nifi
+  service:
+    name: "nifi.service"
+    state: restarted
+    daemon_reload: yes
+    enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,9 +4,11 @@
 
 - name: Install NiFi
   include: install.yml
+  notify: restart_nifi
 
 - name: Customize NiFi
   include: customize.yml
+  notify: restart_nifi
 
 - name: Run NiFi as system service
   include: run.yml

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -4,9 +4,12 @@
     src: "templates/nifi.service.j2"
     dest: "/etc/systemd/system/nifi.service"
 
-- name: Re/Start NiFi
+- name: Flush Handlers
+  meta: flush_handlers
+
+- name: Start NiFi
   service:
     name: "nifi.service"
-    state: restarted
+    state: started
     daemon_reload: yes
     enabled: yes


### PR DESCRIPTION
Changed "Re/Start NiFi" task to only restart when changes are made. This
is to fix idempotency issue where that task will always be changed,
even when not needed.

Because I had to look up what idempotency means, I have linked ansibles definition below:
https://docs.ansible.com/ansible/latest/reference_appendices/glossary.html#:~:text=idempotency