### PR TITLE
Add molecule support and CI testing for multiple distributions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+---
+name: CI
+'on':
+  pull_request:
+  push:
+    branches:
+      - develop
+  schedule:
+    - cron: "30 2 * * 1"
+
+defaults:
+  run:
+    working-directory: 'cavemandaveman.nifi'
+
+jobs:
+
+  molecule:
+    name: Molecule
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro:
+          - centos8
+          - centos7
+          - ubuntu2004
+          - ubuntu1804
+          - debian10
+          - debian9
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'cavemandaveman.nifi'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible molecule[docker] docker
+
+      - name: Run Molecule tests.
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    download_mirror_uri: https://mirrors.gigenet.com/apache
+
+  pre_tasks:
+  - name: Update apt cache.
+    apt: update_cache=true cache_valid_time=600
+    when: ansible_os_family == 'Debian'
+    changed_when: false
+
+  - name: Install lxml through pip
+    pip:
+      name: lxml
+
+  roles:
+  - geerlingguy.java
+  - cavemandaveman.nifi

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,2 @@
+---
+- src: geerlingguy.java


### PR DESCRIPTION
This depends on pull request #9 for CI builds to pass.

Currently will run role with default configuration against the following distributions:
- centos8
- centos7
-  ubuntu2004
-  ubuntu1804
-  debian10 
- debian9

