### PR TITLE
Update to NiFi 1.22.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-nifi_version: 1.14.0
+nifi_version: 1.22.0
 
 # See https://www.apache.org/dyn/closer.lua to find mirrors
 download_mirror_uri: https://apache.claz.org

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 nifi_version: 1.22.0
 
 # See https://www.apache.org/dyn/closer.lua to find mirrors
-download_mirror_uri: https://apache.claz.org
+download_mirror_uri: https://dlcdn.apache.org
 
 nifi_user: nifi
 nifi_group: nifi

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,6 +21,13 @@
     dest: "{{ nifi_config_dirs.binaries }}/nifi-{{ nifi_version }}-bin.zip"
     checksum: "sha256:{{ sha256_sum.content }}"
   when: not tar_file.stat.exists
+  register: get_url_result
+  vars:
+    max_retries: 4
+    retry_interval: 5
+  until: get_url_result is succeeded or retries >= max_retries
+  retries: 4
+  delay: 5
 
 - name: Unpack NiFi binary
   unarchive:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,6 +14,8 @@
   register: sha256_sum
   when: not tar_file.stat.exists
 
+
+
 - name: Download NiFi binary
   get_url:
 
@@ -22,12 +24,8 @@
     checksum: "sha256:{{ sha256_sum.content }}"
   when: not tar_file.stat.exists
   register: get_url_result
-  vars:
-    max_retries: 4
-    retry_interval: 5
-  until: get_url_result is succeeded or retries >= max_retries
-  retries: 4
-  delay: 5
+  until: get_url_result is succeeded
+
 
 - name: Unpack NiFi binary
   unarchive:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if NiFi binary exists
   stat:
-    path: "{{ nifi_config_dirs.binaries }}/nifi-{{ nifi_version }}-bin.tar.gz"
+    path: "{{ nifi_config_dirs.binaries }}/nifi-{{ nifi_version }}-bin.zip"
     get_attributes: no
     get_checksum: no
     get_mime: no
@@ -9,22 +9,23 @@
 
 - name: Get NiFi binary checksum
   uri:
-    url: https://archive.apache.org/dist/nifi/{{ nifi_version }}/nifi-{{ nifi_version }}-bin.tar.gz.sha256
+    url: https://downloads.apache.org/nifi/{{ nifi_version }}/nifi-{{ nifi_version }}-bin.zip.sha256
     return_content: true
   register: sha256_sum
   when: not tar_file.stat.exists
 
 - name: Download NiFi binary
   get_url:
-    url: "{{ download_mirror_uri }}/nifi/{{ nifi_version }}/nifi-{{ nifi_version }}-bin.tar.gz"
-    dest: "{{ nifi_config_dirs.binaries }}/nifi-{{ nifi_version }}-bin.tar.gz"
+
+    url: "{{ download_mirror_uri }}/nifi/{{ nifi_version }}/nifi-{{ nifi_version }}-bin.zip"
+    dest: "{{ nifi_config_dirs.binaries }}/nifi-{{ nifi_version }}-bin.zip"
     checksum: "sha256:{{ sha256_sum.content }}"
   when: not tar_file.stat.exists
 
 - name: Unpack NiFi binary
   unarchive:
     remote_src: "yes"
-    src: "{{ nifi_config_dirs.binaries }}/nifi-{{ nifi_version }}-bin.tar.gz"
+    src: "{{ nifi_config_dirs.binaries }}/nifi-{{ nifi_version }}-bin.zip"
     dest: "{{ nifi_config_dirs.install }}/"
     owner: "{{ nifi_user }}"
     group: "{{ nifi_group }}"

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -27,3 +27,13 @@
     path: "/etc/environment"
     line: "export NIFI_HOME={{ nifi_config_dirs.home }}"
     create: "yes"
+
+- name: Install Python3 pip
+  package:
+    name: python3-pip
+    state: present
+
+- name: Install lxml
+  ansible.builtin.pip:
+    name: lxml
+    state: present

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -28,9 +28,15 @@
     line: "export NIFI_HOME={{ nifi_config_dirs.home }}"
     create: "yes"
 
-- name: Install Python3 pip
-  package:
+
+- name: Install java runtime environment
+  ansible.builtin.package:
     update_cache: yes
+    name: default-jre
+
+- name: Install Python3 pip
+  ansible.builtin.package:
+    update_cache: no
     name: python3-pip
     state: present
 

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -30,6 +30,7 @@
 
 - name: Install Python3 pip
   package:
+    update_cache: yes
     name: python3-pip
     state: present
 


### PR DESCRIPTION
Summary of changes:
- Bumped NiFi version to 1.22.0
- Switched from tarballs to zips (tarball links seem to 404 for us. I'm not sure if others are encountering similar issues)
- Added some lines to `./prepare.yml` to install java, pip3, and lxml. lxml is required for the `ansible.builtin.xml` module, which is used in other parts of the script

